### PR TITLE
Added software-properties-common to the Ubuntu installer script.

### DIFF
--- a/install_ubuntu_dependencies.sh
+++ b/install_ubuntu_dependencies.sh
@@ -30,7 +30,7 @@ sudo apt-get install redis-server
 
 echo ""
 echo "Installing Chris Lea's PPA for the latest versions of Node.js, used as a JS runtime..."
-sudo apt-get install -y python-software-properties
+sudo apt-get install -y python-software-properties software-properties-common
 sudo add-apt-repository ppa:chris-lea/node.js
 sudo apt-get update
 sudo apt-get install -y nodejs


### PR DESCRIPTION
Apparently, Ubuntu 14.04 can't add new PPAs without the software-properties-common package installed.
